### PR TITLE
CSS tweak.

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -242,3 +242,11 @@ html { min-width: 650px; /* anything smaller than this is Work. */ }
 
 
 }
+
+
+@media (max-width: 650px)
+/* Phones are jerks. */ {
+
+.header-box { display: none; }
+
+}


### PR DESCRIPTION
Hides the adbox in small viewports.  Keeps the bottom spacing, which should look better on phones. :+1:
